### PR TITLE
bsconfig: add namespace

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,6 @@
 {
   "name": "bs-node",
+  "namespace": true,
   "bsc-flags": ["-bs-no-version-header", "-bs-super-errors"],
   "sources": [
     {


### PR DESCRIPTION
Adds a namespace `BsNode` so we play nice with bs-platform's Node module.

Fixes #7.