### PR TITLE
Fix hmac bindings

### DIFF
--- a/src/NodeCrypto.re
+++ b/src/NodeCrypto.re
@@ -1,14 +1,15 @@
 module Hmac: {
   type t;
   let create: ([ | `SHA256 | `SHA512 | `SHA384 | `SHA1 | `MD5], string) => t;
-  let appendString: (t, string) => unit;
-  let appendBuffer: (t, NodeBuffer.t) => unit;
+  let appendString: (t, string) => t;
+  let appendBuffer: (t, NodeBuffer.t) => t;
   let toBase64: t => string;
+  let toHex: t => string;
   let toBuffer: t => NodeBuffer.t;
 } = {
   type t;
   [@bs.module "crypto"]
-  external create :
+  external create:
     (
       [@bs.string] [
         | [@bs.as "sha256"] `SHA256
@@ -22,14 +23,15 @@ module Hmac: {
     t =
     "createHmac";
   [@bs.send]
-  external update :
-    (t, [@bs.unwrap] [ | `String(string) | `Buffer(NodeBuffer.t)]) => unit =
+  external update:
+    (t, [@bs.unwrap] [ | `String(string) | `Buffer(NodeBuffer.t)]) => t =
     "";
   let appendString = (hmac, str) => update(hmac, `String(str));
   let appendBuffer = (hmac, buffer) => update(hmac, `Buffer(buffer));
-  [@bs.send] external digest : (t, Js.Nullable.t(string)) => 'a = "";
+  [@bs.send] external digest: (t, Js.Nullable.t(string)) => 'a = "";
   let toBase64: t => string =
     hmac => digest(hmac, Js.Nullable.return("base64"));
+  let toHex: t => string = hmac => digest(hmac, Js.Nullable.return("hex"));
   let toBuffer: t => NodeBuffer.t =
     hmac => digest(hmac, Js.Nullable.undefined);
 };
@@ -44,7 +46,7 @@ module Hash: {
 } = {
   type t;
   [@bs.module "crypto"]
-  external create :
+  external create:
     (
     [@bs.string]
     [
@@ -58,12 +60,12 @@ module Hash: {
     t =
     "createHash";
   [@bs.send]
-  external update :
+  external update:
     (t, [@bs.unwrap] [ | `String(string) | `Buffer(NodeBuffer.t)]) => unit =
     "";
   let appendString = (hmac, str) => update(hmac, `String(str));
   let appendBuffer = (hmac, buffer) => update(hmac, `Buffer(buffer));
-  [@bs.send] external digest : (t, Js.Nullable.t(string)) => 'a = "";
+  [@bs.send] external digest: (t, Js.Nullable.t(string)) => 'a = "";
   let toBase64: t => string =
     hmac => digest(hmac, Js.Nullable.return("base64"));
   let toBuffer: t => NodeBuffer.t =


### PR DESCRIPTION
Previously it was not possible to do something like this: `Crypto.Hmac.(create(`SHA256, hmacKey)->appendString(str)->toHex)` which is totally valid.